### PR TITLE
Minor fixes and updates

### DIFF
--- a/src/Mapex.Tests/Properties/AssemblyInfo.cs
+++ b/src/Mapex.Tests/Properties/AssemblyInfo.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Mapex.Tests")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Provides a dynamic mapping engine to extract, transform and load data using YAML directives.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Alexander Forbes Group Services (Pty) Ltd.")]
 [assembly: AssemblyProduct("Mapex.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyCopyright("Copyright (c) 2021 Alexander Forbes Group Services (Pty) Ltd.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.1.0")]
-[assembly: AssemblyFileVersion("5.1.0")]
+[assembly: AssemblyVersion("6.5.2")]
+[assembly: AssemblyFileVersion("6.5.2")]

--- a/src/Mapex.sln
+++ b/src/Mapex.sln
@@ -7,6 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapex", "Mapex\Mapex.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mapex.Tests", "Mapex.Tests\Mapex.Tests.csproj", "{AA8E7031-E805-4D54-8D66-0B6B60148DA5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{300D0C7A-6872-40F7-A714-55874E3A7FAC}"
+	ProjectSection(SolutionItems) = preProject
+		..\LICENSE = ..\LICENSE
+		..\README.md = ..\README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Mapex/Deserialization/DirectiveDeserializerFactory.cs
+++ b/src/Mapex/Deserialization/DirectiveDeserializerFactory.cs
@@ -31,7 +31,7 @@ namespace Mapex.Deserialization
 		private static IYamlDeserializer BuildYamlDeserializer(TagMap tagMap)
 		{
 			var builder = new DeserializerBuilder();
-			builder.WithNamingConvention(new CamelCaseNamingConvention());
+			builder.WithNamingConvention(CamelCaseNamingConvention.Instance);
 
 			foreach (var mapping in tagMap)
 			{

--- a/src/Mapex/Mapex.csproj
+++ b/src/Mapex/Mapex.csproj
@@ -13,12 +13,6 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-		<PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.3.246501">
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-	</ItemGroup>
-	<ItemGroup>
 		<PackageReference Include="AutoMapper" Version="10.1.1" />
 		<PackageReference Include="Notus" Version="2.0.0" />
 		<PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.13" />

--- a/src/Mapex/Properties/AssemblyInfo.cs
+++ b/src/Mapex/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.5.1")]
-[assembly: AssemblyFileVersion("6.5.1")]
+[assembly: AssemblyVersion("6.5.2")]
+[assembly: AssemblyFileVersion("6.5.2")]
 [assembly: InternalsVisibleTo("Mapex.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
- This version fixes a minor deprecation warning. 
- Updates the AssemblyInfo.cs files to standard.
- Removes unnecessary package references that are part of .NET Standard 2.1. 
